### PR TITLE
FIX: success message being displayed on empty notes

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,8 +5,8 @@ let done = document.getElementById("editBtn");
 let addtext = document.getElementById("addTxt");
 let searchTxt = document.getElementById("searchTxt");
 let heading = document.getElementById("heading");
-let volumeButton = document.getElementById('mute-button');
-done.style.visibility="hidden";
+let volumeButton = document.getElementById("mute-button");
+done.style.visibility = "hidden";
 //Event listeners
 addbtn.addEventListener("click", addaNote);
 searchTxt.addEventListener("input", searchtext);
@@ -22,7 +22,7 @@ function showNotes() {
   }
   let html = "";
   notesArray.forEach(function (element, index) {
-    console.log
+    console.log;
     html += `
             <div class="noteCard my-2 mx-2 card" style="width: 18rem;">
                     <div class="card-body">
@@ -45,7 +45,7 @@ function showNotes() {
 
 function addaNote() {
   const audio = document.querySelector(".sound");
-  if (volumeButton.classList.contains('fa-volume-up')) {
+  if (volumeButton.classList.contains("fa-volume-up")) {
     audio.play();
   }
   let notes = localStorage.getItem("notes");
@@ -55,50 +55,45 @@ function addaNote() {
     notesArray = JSON.parse(notes);
   }
   if (addtext.value !== "") {
-    notesArray.push([heading.value,addtext.value]);
+    notesArray.push([heading.value, addtext.value]);
     localStorage.setItem("notes", JSON.stringify(notesArray));
     addtext.value = "";
-    heading.value="";  
+    heading.value = "";
+    $(".toast").toast("show");
   } else {
     alert("Notes cannot be empty");
   }
   showNotes();
-
-  // displaying toast message
-  $(".toast").toast("show");
 }
 
-function editNote(index){
-            addbtn.style.visibility="collapse";
-            done.style.visibility="visible";
-            let notes = localStorage.getItem("notes");
-            if (notes == null) {
-              notesObj = [];
-            } else {
-              notesObj = JSON.parse(notes);
-            }
-            heading.value=notesObj[index][0];
-            addtext.value=notesObj[index][1];
-            done.onclick=()=>{
-              const update=[heading.value,addtext.value];
-              if(update.length>0){
-              notesObj.splice(index,1,update);
-              localStorage.setItem("notes", JSON.stringify(notesObj));
-              showNotes();
-              heading.value="";
-              addtext.value="";
-              addbtn.style.visibility="visible";
-              done.style.visibility="hidden";
-              
-              
-          }
-              else{
-                   window.alert("Can not be empty,Your item will get delted.");
-                   notesObj.splice(index,1);
-                   localStorage.setItem("notes", JSON.stringify(notesObj));
-                   showNotes();
-              }
-           }
+function editNote(index) {
+  addbtn.style.visibility = "collapse";
+  done.style.visibility = "visible";
+  let notes = localStorage.getItem("notes");
+  if (notes == null) {
+    notesObj = [];
+  } else {
+    notesObj = JSON.parse(notes);
+  }
+  heading.value = notesObj[index][0];
+  addtext.value = notesObj[index][1];
+  done.onclick = () => {
+    const update = [heading.value, addtext.value];
+    if (update.length > 0) {
+      notesObj.splice(index, 1, update);
+      localStorage.setItem("notes", JSON.stringify(notesObj));
+      showNotes();
+      heading.value = "";
+      addtext.value = "";
+      addbtn.style.visibility = "visible";
+      done.style.visibility = "hidden";
+    } else {
+      window.alert("Can not be empty,Your item will get delted.");
+      notesObj.splice(index, 1);
+      localStorage.setItem("notes", JSON.stringify(notesObj));
+      showNotes();
+    }
+  };
 }
 
 function deleteNote(index) {
@@ -157,12 +152,11 @@ function toggleTheme() {
 })();
 
 function toggleMute() {
-  if (volumeButton.classList.contains('fa-volume-mute')) {
-    volumeButton.classList.remove('fa-volume-mute');
-    volumeButton.classList.add('fa-volume-up');
-  }
-  else {
-    volumeButton.classList.remove('fa-volume-up');
-    volumeButton.classList.add('fa-volume-mute');
+  if (volumeButton.classList.contains("fa-volume-mute")) {
+    volumeButton.classList.remove("fa-volume-mute");
+    volumeButton.classList.add("fa-volume-up");
+  } else {
+    volumeButton.classList.remove("fa-volume-up");
+    volumeButton.classList.add("fa-volume-mute");
   }
 }


### PR DESCRIPTION
This pull request addresses an issue where the success message was incorrectly displayed even when attempting to add an empty note. The fix ensures that the success message is only shown on successful note additions

Closes #12 