### PR TITLE
fix: Height and width of the notes container

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
             </div>
         </div>
         <h3 style="color: rgb(134, 153, 237); margin-top: 8px;">Your Notes</h3>
-        <div id="notes" class="row container-fluid"> </div>
+        <div id="notes" class="row container-fluid align-items-start"> </div>
     </div>
 </div>
 


### PR DESCRIPTION
The height and width of the container are now fixed to content.

Fixes #21 

![Screenshot 2023-12-31 014317](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/116517217/f8492884-eb21-411b-aec0-bb4a748cd38f)

- Bug fix (non-breaking change which fixes an issue)

- [X] Self-reviewed the code. 