### PR TITLE
Fixes empty title issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,18 +54,38 @@ function addaNote() {
   } else {
     notesArray = JSON.parse(notes);
   }
+  let useDefaultTitle = document.getElementById("useDefaultTitle").checked;
   if (addtext.value !== "") {
-    notesArray.push([heading.value,addtext.value]);
-    localStorage.setItem("notes", JSON.stringify(notesArray));
-    addtext.value = "";
-    heading.value="";  
-  } else {
+    if (heading.value === "" && useDefaultTitle){
+      let title = getDefaultTitle(addtext.value);
+      notesArray.push([title, addtext.value]);
+      localStorage.setItem("notes", JSON.stringify(notesArray));
+      addtext.value = "";
+      heading.value = "";
+     }
+     else if(heading.value === "" && !useDefaultTitle){
+       alert("Title cannot be empty.Please Click the checkbox for Default title or Enter the Title.");
+     }
+     else {
+       let title = heading.value;
+       notesArray.push([title, addtext.value]);
+       localStorage.setItem("notes", JSON.stringify(notesArray));
+       addtext.value = "";
+       heading.value = "";
+     } 
+ 
+   } else {
     alert("Notes cannot be empty");
   }
   showNotes();
 
   // displaying toast message
   $(".toast").toast("show");
+}
+// Function to get default title from the first two words of text
+function getDefaultTitle(text) {
+  let words = text.split(" ");
+  return words.length >= 2 ? `${words[0]} ${words[1]}` : text;
 }
 
 function editNote(index){

--- a/index.html
+++ b/index.html
@@ -78,6 +78,8 @@
                 </h5>
                 <div class="form-group">
                     <textarea class="form-control" id="heading" rows="1" placeholder="Title"></textarea> <br>
+                    <!-- Adding checkbox in  HTML -->
+                    <input type="checkbox" id="useDefaultTitle"> Use Default Title <br>
                     <textarea class="form-control" id="addTxt" rows="3" placeholder="Note"></textarea>
                 </div>
                 <button class="btn btn-primary" id="addBtn" style="margin-top: 7px;">Add Note</button>


### PR DESCRIPTION
Fixes issue #18  by providing a checkbox for selecting title by default or showing an alert message if the box is unchecked and title is empty.
 solution:
![Screenshot 2023-12-31 205927](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/112767165/278ae3a8-b8ed-4eac-b234-5b1895f3fab7)
![Screenshot 2023-12-31 210002](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/112767165/466c9db0-010c-4256-81ba-77509fbf538c)
