### PR TITLE
ADD: Toast message instead of alert for empty title

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ function addaNote() {
      }
      else if(heading.value === "" && !useDefaultTitle){
       styledTitle.innerHTML =
-        '<div class="alert alert-warning" role="alert">Title cannot be empty! Please enter a title or check the below box for default title</div>';
+        '<div class="alert alert-warning" role="alert" style="background: #b5f2fb;">Title cannot be empty! Please enter a title or check the below box for default title</div>';
       setTimeout(() => {
         styledTitle.innerHTML = "";
       }

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ let searchTxt = document.getElementById("searchTxt");
 let heading = document.getElementById("heading");
 let volumeButton = document.getElementById("mute-button");
 let styledMessageContainer = document.getElementById("styled-message-container");
+let styledTitle = document.getElementById("styled-title");
 done.style.visibility = "hidden";
 //Event listeners
 addbtn.addEventListener("click", addaNote);
@@ -67,7 +68,12 @@ function addaNote() {
     }
      }
      else if(heading.value === "" && !useDefaultTitle){
-       alert("Title cannot be empty.Please Click the checkbox for Default title or Enter the Title.");
+      styledTitle.innerHTML =
+        '<div class="alert alert-warning" role="alert">Title cannot be empty! Please enter a title or check the below box for default title</div>';
+      setTimeout(() => {
+        styledTitle.innerHTML = "";
+      }
+      , 4000);
      }
      else {
        let title = heading.value;

--- a/index.html
+++ b/index.html
@@ -78,7 +78,9 @@
                     <audio src="sounds/mixkit-tile-game-reveal-960.wav" class="sound"></audio>
                 </h5>
                 <div class="form-group">
-                    <textarea class="form-control" id="heading" rows="1" placeholder="Title"></textarea> <br>
+                    <textarea class="form-control" id="heading" rows="1" placeholder="Title"></textarea> 
+                    <p id="styled-title"></p>
+                    <br>
                     <!-- Adding checkbox in  HTML -->
                     <input type="checkbox" id="useDefaultTitle"> Use Default Title <br>
                     <textarea class="form-control" id="addTxt" rows="3" placeholder="Note" 


### PR DESCRIPTION
This PR closes #39  and displays a beautiful toast message instead of an alert when the title section is empty

Light Mode:

![image](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/97835955/80eeb6f4-8fc4-4899-bd90-3c98c210afb4)

Dark Mode:

![image](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/97835955/131bfd9f-207a-4b17-a341-2b2ee68b1795)
