### PR TITLE
showing alert messages if the title and note are empty after editing

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,35 +128,51 @@ function editNote(index) {
   } else {
     notesObj = JSON.parse(notes);
   }
+
   heading.value = notesObj[index][0].replace(/ \(Edited\) .*/, '');
   addtext.value = notesObj[index][1];
-  let d = new Date();
-  let n = d.toLocaleTimeString();
 
   done.onclick = () => {
+    const updatedHeading = heading.value.trim(); // Trim leading and trailing spaces
+    const updatedAddText = addtext.value.trim(); // Trim leading and trailing spaces
 
-    const update = [heading.value + " (Edited) " + " " + n, addtext.value];
-    console.log(update);
+    if (!updatedAddText) {
+      window.alert("Note cannot be empty. Your item will be deleted.");
+      notesObj.splice(index, 1);
+      localStorage.setItem("notes", JSON.stringify(notesObj));
+      showNotes();
+    } else {
+      let headingString = updatedHeading;
 
-    
-    if (update.length > 0) {
+      // Check if "Use Default Title" option is checked
+      if (document.getElementById("useDefaultTitle").checked) {
+        // Use the first two words of addtext as the title
+        const words = updatedAddText.split(" ");
+        headingString = words.length >= 2 ? `${words[0]} ${words[1]}` : updatedHeading;
+      }
+
+      // Check if heading is not empty before appending "(Edited) " + " " + n
+      if (headingString) {
+        headingString += " (Edited) " + new Date().toLocaleTimeString();
+        const update = [headingString, updatedAddText];
+
       notesObj.splice(index, 1, update);
-
       localStorage.setItem("notes", JSON.stringify(notesObj));
       showNotes();
       heading.value = "";
       addtext.value = "";
-
       addbtn.style.visibility = "visible";
       done.style.visibility = "hidden";
-    } else {
-      window.alert("Can not be empty,Your item will get delted.");
-      notesObj.splice(index, 1);
-      localStorage.setItem("notes", JSON.stringify(notesObj));
-      showNotes();
+      } 
+      else {
+        // Heading is empty, show an alert message
+        window.alert("Heading cannot be empty.");
+      }
     }
   };
 }
+
+
 
 function deleteNote(index) {
   //   console.log("I am deleting", index);


### PR DESCRIPTION
solves #59 by showing alert messages if the title and note are empty after editing the content.
solution:
![Screenshot 2024-01-05 143744](https://github.com/SnowScriptWinterOfCode/Notes-App/assets/112767165/1d631758-03cb-44bb-9418-6d53c63d70e0)

Please review the PR.